### PR TITLE
Fix Sequence of Recommended Start Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ $ virtualenv -p python3 .
 $ source bin/activate
 (channels-rapid) $ pip install -r requirements.txt
 (channels-rapid) $ cd src
+(channels-rapid) $ python manage.py migrate
 (channels-rapid) $ python manage.py createsuperuser
 ... do the creation
 (channels-rapid) $ python manage.py createsuperuser

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ YouTube Video: __coming soon__
 
 
 ### Recommended Start
-```
+```bash
 
 $ cd path/to/your/dev/folder
 $ mkdir channels-rapid
@@ -17,8 +17,8 @@ $ git reset a9a2c42052c87fd2eb5acdc417729f9359a1e087 --hard
 $ git remote remove origin
 $ virtualenv -p python3 .
 $ source bin/activate
-(channels-rapid) $ cd src
 (channels-rapid) $ pip install -r requirements.txt
+(channels-rapid) $ cd src
 (channels-rapid) $ python manage.py createsuperuser
 ... do the creation
 (channels-rapid) $ python manage.py createsuperuser


### PR DESCRIPTION
Fix for #1.

- Changed the order of commands needed to properly install `requirements.txt`.

- Added a `migrate` step before `createsuperuser`