### PR TITLE
fix success url path

### DIFF
--- a/src/chat/urls.py
+++ b/src/chat/urls.py
@@ -6,5 +6,5 @@ from .views import ThreadView, InboxView
 app_name = 'chat'
 urlpatterns = [
     path("", InboxView.as_view()),
-    re_path(r"^(?P<username>[\w.@+-]+)", ThreadView.as_view()),
+    re_path(r"^(?P<username>[\w.@+-]+)/", ThreadView.as_view()),
 ]

--- a/src/chat/views.py
+++ b/src/chat/views.py
@@ -19,7 +19,9 @@ class InboxView(LoginRequiredMixin, ListView):
 class ThreadView(LoginRequiredMixin, FormMixin, DetailView):
     template_name = 'chat/thread.html'
     form_class = ComposeForm
-    success_url = './'
+    
+    def get_success_url(self):
+        return self.request.path
 
     def get_queryset(self):
         return Thread.objects.by_user(self.request.user)


### PR DESCRIPTION
initial project success url doesn't work right when the user click submit button, user redirected to '_messages/_' not '_messages/<to_user>/_'

there are two ways to fix
- we can fix it with adding '_/_' end of url like _re_path(".../", ....as_view()_)
- or we can change success_url as current path

this pr includes both of them